### PR TITLE
Fix import error

### DIFF
--- a/RoboToDo.roboFontExt/info.plist
+++ b/RoboToDo.roboFontExt/info.plist
@@ -43,9 +43,9 @@
 		<string>Embedded to-do tracker with font- and glyph-scoped to-do items</string>
 	</dict>
 	<key>timeStamp</key>
-	<real>1364306316.999585</real>
+	<real>1552324595.0</real>
 	<key>version</key>
-	<string>1.1</string>
+	<string>1.2</string>
 	<key>requiresVersionMajor</key>
 	<string>1</string>
 	<key>requiresVersionMinor</key>

--- a/RoboToDo.roboFontExt/lib/todo/helpers.py
+++ b/RoboToDo.roboFontExt/lib/todo/helpers.py
@@ -3,7 +3,7 @@ from vanilla import *
 
 from mojo.UI import CurrentFontWindow
 
-from models import *
+from todo.models import *
 
 def doubleClickCallback(sender):
     pass


### PR DESCRIPTION
I noticed an import error in RF3, (no module `models` found), and this commit fixes it.
Presumably this is related to https://www.python.org/dev/peps/pep-0328/#guido-s-decision